### PR TITLE
zsh fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is useful if you work on a project that squashes branches into master. Afte
 To run as a shellscript, simply copy the following command (setting up an alias is recommended). There's no need to clone the repo.
 
 ```bash
-git checkout -q master && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base master $branch) && [[ $(git cherry master $(git commit-tree $(git rev-parse $branch^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
+git checkout -q master && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base master $branch) && [[ $(git cherry master $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
 ```
 
 ### Node.js


### PR DESCRIPTION
Will probably fix also #4 after adaptation to npm script. This is somehow similar to #6 but changes only 1 char without adding new section.

## Environment
- git: 2.24.1
- os: MacOS Catalina 10.15.1
- zsh: 5.7.1

## Problem:
```
zsh: no matches found: RDEV-533/crm/customer-service-optimisation^{tree}
fatal: must give exactly one tree
```

## Fix:
```diff
- $branch^{tree}
+ $branch\^{tree}
```

Fix Was also tested (it works) with bash-5.0.11 and git-2.24.1