### PR TITLE
Delete merged and squashed from other branches.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,18 +18,14 @@ git checkout -q master && git for-each-ref refs/heads/ "--format=%(refname:short
 
 You can also install the tool as a Node.js package from NPM. (The package code is in this repo.)
 
+Additionally, you can specify an alternate branch to check for squashed merges, as well. This is useful for different names of trunk branches like `main` or `develop`.
+
 ```bash
 $ npm install --global git-delete-squashed
 $ git-delete-squashed
-```
-
-You can specify an alternate branch to check for squashed merges, as well. This is useful for different names of trunk branches like `main` or `develop`.
-
-```bash
-$ npm install --global git-delete-squashed
+$ # Specify a different branch name like so
 $ git-delete-squashed main
 ```
-
 
 ## Details
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,16 @@ This is useful if you work on a project that squashes branches into master. Afte
 To run as a shellscript, simply copy the following command (setting up an alias is recommended). There's no need to clone the repo.
 
 ```bash
-git checkout -q master && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base master $branch) && [[ $(git cherry master $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
+# Change $TARGET_BRANCH to your targeted branch, e.g. change from `master` to `main` to delete branches squased into `main`.
+export TARGET_BRANCH=master && git checkout -q $TARGET_BRANCH && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $TARGET_BRANCH $branch) && [[ $(git cherry $TARGET_BRANCH $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
+# OR you can put this function in your shell config and call it like this
+# `git-delete-squashed` OR `git-delete-squased main`
+function git-delete-squashed() {
+    local targetBranch = ${$1-:master}
+    git checkout -q $targetBranch;
+    git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $targetBranch $branch) && [[ $(git cherry $targetBranch $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done;
+    return 0;
+}
 ```
 
 ### Node.js

--- a/README.md
+++ b/README.md
@@ -13,14 +13,9 @@ To run as a shellscript, simply copy the following command (setting up an alias 
 ```bash
 # Change $TARGET_BRANCH to your targeted branch, e.g. change from `master` to `main` to delete branches squashed into `main`.
 TARGET_BRANCH=master && git checkout -q $TARGET_BRANCH && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $TARGET_BRANCH $branch) && [[ $(git cherry $TARGET_BRANCH $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
-# OR you can put this function in your shell config and call it like this
-# `git-delete-squashed` OR `git-delete-squased main`
-function git-delete-squashed() {
-    local targetBranch = ${$1-:master}
-    git checkout -q $targetBranch;
-    git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $targetBranch $branch) && [[ $(git cherry $targetBranch $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done;
-    return 0;
-}
+# OR you can put this function in a global git alias and call it like this
+# `git delete-squashed` OR `git delete-squashed main`
+git config --global alias.delete-squashed '!f() { local targetBranch=${1:-master} && git checkout -q $targetBranch && git branch --merged | grep -v "\*" | xargs -n 1 git branch -d && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $targetBranch $branch) && [[ $(git cherry $targetBranch $(git commit-tree $(git rev-parse $branch^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done; }; f'
 ```
 
 ### Node.js

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ To run as a shellscript, simply copy the following command (setting up an alias 
 
 ```bash
 # Change $TARGET_BRANCH to your targeted branch, e.g. change from `master` to `main` to delete branches squased into `main`.
-export TARGET_BRANCH=master && git checkout -q $TARGET_BRANCH && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $TARGET_BRANCH $branch) && [[ $(git cherry $TARGET_BRANCH $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
+TARGET_BRANCH=master && git checkout -q $TARGET_BRANCH && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $TARGET_BRANCH $branch) && [[ $(git cherry $TARGET_BRANCH $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
 # OR you can put this function in your shell config and call it like this
 # `git-delete-squashed` OR `git-delete-squased main`
 function git-delete-squashed() {

--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ $ npm install --global git-delete-squashed
 $ git-delete-squashed
 ```
 
+You can specify an alternate branch to check for squashed merges, as well. This is useful for different names of trunk branches like `main` or `develop`.
+
+```bash
+$ npm install --global git-delete-squashed
+$ git-delete-squashed main
+```
+
+
 ## Details
 
 To determine if a branch is squash-merged, git-delete-squashed creates a temporary dangling squashed commit with [`git commit-tree`](https://git-scm.com/docs/git-commit-tree). Then it uses [`git cherry`](https://git-scm.com/docs/git-cherry) to check if the squashed commit has already been applied to `master`. If so, it deletes the branch.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This is useful if you work on a project that squashes branches into master. Afte
 To run as a shellscript, simply copy the following command (setting up an alias is recommended). There's no need to clone the repo.
 
 ```bash
-# Change $TARGET_BRANCH to your targeted branch, e.g. change from `master` to `main` to delete branches squased into `main`.
+# Change $TARGET_BRANCH to your targeted branch, e.g. change from `master` to `main` to delete branches squashed into `main`.
 TARGET_BRANCH=master && git checkout -q $TARGET_BRANCH && git for-each-ref refs/heads/ "--format=%(refname:short)" | while read branch; do mergeBase=$(git merge-base $TARGET_BRANCH $branch) && [[ $(git cherry $TARGET_BRANCH $(git commit-tree $(git rev-parse $branch\^{tree}) -p $mergeBase -m _)) == "-"* ]] && git branch -D $branch; done
 # OR you can put this function in your shell config and call it like this
 # `git-delete-squashed` OR `git-delete-squased main`

--- a/bin/git-delete-squashed.js
+++ b/bin/git-delete-squashed.js
@@ -5,6 +5,7 @@
 const childProcess = require('child_process');
 const Promise = require('bluebird');
 const DEFAULT_BRANCH_NAME = 'master';
+let selectedBranchName;
 
 /**
  * Calls `git` with the given arguments from the CWD
@@ -25,23 +26,27 @@ function git (args) {
   }).then(stdout => stdout.replace(/\n$/, ''));
 }
 
+if (process.argv.length > 0) {
+  selectedBranchName = process.argv[1];
+}
+
 git(['for-each-ref', 'refs/heads/', '--format=%(refname:short)'])
   .then(branchListOutput => branchListOutput.split('\n'))
   .tap(branchNames => {
-    if (branchNames.indexOf(DEFAULT_BRANCH_NAME) === -1) {
-      throw `fatal: no branch named '${DEFAULT_BRANCH_NAME}' found in this repo`;
+    if (branchNames.indexOf((selectedBranchName || DEFAULT_BRANCH_NAME)) === -1) {
+      throw `fatal: no branch named '${selectedBranchName || DEFAULT_BRANCH_NAME}' found in this repo`;
     }
   }).filter(branchName =>
     // Get the common ancestor with the branch and master
     Promise.join(
-      git(['merge-base', DEFAULT_BRANCH_NAME, branchName]),
+      git(['merge-base', selectedBranchName || DEFAULT_BRANCH_NAME, branchName]),
       git(['rev-parse', `${branchName}^{tree}`]),
       (ancestorHash, treeId) => git(['commit-tree', treeId, '-p', ancestorHash, '-m', `Temp commit for ${branchName}`])
     )
-      .then(danglingCommitId => git(['cherry', DEFAULT_BRANCH_NAME, danglingCommitId]))
+      .then(danglingCommitId => git(['cherry', selectedBranchName || DEFAULT_BRANCH_NAME, danglingCommitId]))
       .then(output => output.startsWith('-'))
   )
-  .tap(branchNamesToDelete => branchNamesToDelete.length && git(['checkout', DEFAULT_BRANCH_NAME]))
+  .tap(branchNamesToDelete => branchNamesToDelete.length && git(['checkout', selectedBranchName || DEFAULT_BRANCH_NAME]))
   .mapSeries(branchName => git(['branch', '-D', branchName]))
   .mapSeries(stdout => console.log(stdout))
   .catch(err => console.error(err.cause || err));

--- a/bin/git-delete-squashed.js
+++ b/bin/git-delete-squashed.js
@@ -5,7 +5,7 @@
 const childProcess = require('child_process');
 const Promise = require('bluebird');
 const DEFAULT_BRANCH_NAME = 'master';
-const RUN_WITH_NODE = process.argv[0].includes("node");
+const RUN_WITH_NODE = process.argv[0].includes('node');
 const selectedBranchName = process.argv[RUN_WITH_NODE ? 2 : 1] || DEFAULT_BRANCH_NAME;
 
 /**
@@ -30,7 +30,7 @@ function git (args) {
 git(['for-each-ref', 'refs/heads/', '--format=%(refname:short)'])
   .then(branchListOutput => branchListOutput.split('\n'))
   .tap(branchNames => {
-    if (branchNames.indexOf((selectedBranchName)) === -1) {
+    if (branchNames.indexOf(selectedBranchName) === -1) {
       throw `fatal: no branch named '${selectedBranchName}' found in this repo`;
     }
   }).filter(branchName =>

--- a/bin/git-delete-squashed.js
+++ b/bin/git-delete-squashed.js
@@ -5,7 +5,8 @@
 const childProcess = require('child_process');
 const Promise = require('bluebird');
 const DEFAULT_BRANCH_NAME = 'master';
-const selectedBranchName = process.argv[1] || DEFAULT_BRANCH_NAME;
+const RUN_WITH_NODE = process.argv[0].includes("node");
+const selectedBranchName = process.argv[RUN_WITH_NODE ? 2 : 1] || DEFAULT_BRANCH_NAME;
 
 /**
  * Calls `git` with the given arguments from the CWD


### PR DESCRIPTION
This defaults to master currently, my change proposes that the script should take an argument and allow squashed branches to be pruned no matter where they were merged.