### PR TITLE
determine default branch name instead of always using `master`

### DIFF
--- a/bin/git-delete-squashed.js
+++ b/bin/git-delete-squashed.js
@@ -25,23 +25,37 @@ function git (args) {
   }).then(stdout => stdout.replace(/\n$/, ''));
 }
 
-git(['for-each-ref', 'refs/heads/', '--format=%(refname:short)'])
-  .then(branchListOutput => branchListOutput.split('\n'))
-  .tap(branchNames => {
-    if (branchNames.indexOf(DEFAULT_BRANCH_NAME) === -1) {
-      throw `fatal: no branch named '${DEFAULT_BRANCH_NAME}' found in this repo`;
-    }
-  }).filter(branchName =>
-    // Get the common ancestor with the branch and master
-    Promise.join(
-      git(['merge-base', DEFAULT_BRANCH_NAME, branchName]),
-      git(['rev-parse', `${branchName}^{tree}`]),
-      (ancestorHash, treeId) => git(['commit-tree', treeId, '-p', ancestorHash, '-m', `Temp commit for ${branchName}`])
+function deleteSquashed(branchName = DEFAULT_BRANCH_NAME) {
+  git(['for-each-ref', 'refs/heads/', '--format=%(refname:short)'])
+    .then(branchListOutput => branchListOutput.split('\n'))
+    .tap(branchNames => {
+      if (branchNames.indexOf(branchName) === -1) {
+        throw `fatal: no branch named '${branchName}' found in this repo`;
+      }
+    }).filter(branchName =>
+      // Get the common ancestor with the branch and master
+      Promise.join(
+        git(['merge-base', branchName, branchName]),
+        git(['rev-parse', `${branchName}^{tree}`]),
+        (ancestorHash, treeId) => git(['commit-tree', treeId, '-p', ancestorHash, '-m', `Temp commit for ${branchName}`])
+      )
+        .then(danglingCommitId => git(['cherry', branchName, danglingCommitId]))
+        .then(output => output.startsWith('-'))
     )
-      .then(danglingCommitId => git(['cherry', DEFAULT_BRANCH_NAME, danglingCommitId]))
-      .then(output => output.startsWith('-'))
-  )
-  .tap(branchNamesToDelete => branchNamesToDelete.length && git(['checkout', DEFAULT_BRANCH_NAME]))
-  .mapSeries(branchName => git(['branch', '-D', branchName]))
-  .mapSeries(stdout => console.log(stdout))
-  .catch(err => console.error(err.cause || err));
+    .tap(branchNamesToDelete => branchNamesToDelete.length && git(['checkout', branchName]))
+    .mapSeries(branchName => git(['branch', '-D', branchName]))
+    .mapSeries(stdout => console.log(stdout))
+    .catch(err => console.error(err.cause || err));
+}
+
+git(['symbolic-ref', 'refs/remotes/origin/HEAD'])
+  .then(ref => ref.substr(20))
+  .then(branchName => {
+    deleteSquashed(branchName);
+  })
+  .catch(() => {
+    git(['config', 'init.defaultBranch'])
+      .then(branchName => deleteSquashed(branchName))
+      .catch(() => deleteSquashed());
+  });
+


### PR DESCRIPTION
Instead of always using `master`, we request the ref of the HEAD. If that fails, we fallback to the `init.defaultBranch` configuration. And if that fails, we use `master` as default branch.